### PR TITLE
Fixes problem of adding tenant to model discriminators

### DIFF
--- a/index.js
+++ b/index.js
@@ -311,7 +311,8 @@ class MongoTenant {
         continue;
       }
 
-      MongoTenantModel[staticProperty] = BaseModel[staticProperty];
+      let descriptor = Object.getOwnPropertyDescriptor(BaseModel, staticProperty)
+      Object.defineProperty(MongoTenantModel, staticProperty, descriptor)
     }
 
     return MongoTenantModel;

--- a/index.js
+++ b/index.js
@@ -311,8 +311,8 @@ class MongoTenant {
         continue;
       }
 
-      let descriptor = Object.getOwnPropertyDescriptor(BaseModel, staticProperty)
-      Object.defineProperty(MongoTenantModel, staticProperty, descriptor)
+      let descriptor = Object.getOwnPropertyDescriptor(BaseModel, staticProperty);
+      Object.defineProperty(MongoTenantModel, staticProperty, descriptor);
     }
 
     return MongoTenantModel;

--- a/index.js
+++ b/index.js
@@ -315,6 +315,15 @@ class MongoTenant {
       Object.defineProperty(MongoTenantModel, staticProperty, descriptor);
     }
 
+    // create tenant models for discriminators if they exist
+    if(BaseModel.discriminators) {
+      MongoTenantModel.discriminators = {};
+
+      for (let key in BaseModel.discriminators) {
+        MongoTenantModel.discriminators[key] = this.createTenantAwareModel(BaseModel.discriminators[key], tenantId);
+      }
+    }
+
     return MongoTenantModel;
   }
 

--- a/index.js
+++ b/index.js
@@ -316,7 +316,7 @@ class MongoTenant {
     }
 
     // create tenant models for discriminators if they exist
-    if(BaseModel.discriminators) {
+    if (BaseModel.discriminators) {
       MongoTenantModel.discriminators = {};
 
       for (let key in BaseModel.discriminators) {

--- a/test/_utils.js
+++ b/test/_utils.js
@@ -18,9 +18,9 @@ let testModelUnifier = 0;
 mongoose.Promise = Promise;
 
 function createTestModel(schemaDefinition, options) {
-  let schema = new Schema(schemaDefinition);
-
   options = options || {};
+  
+  let schema = new Schema(schemaDefinition, options.schemaOptions);
 
   if (typeof options.applyOnSchema === 'function') {
     options.applyOnSchema(schema);

--- a/test/middleware.js
+++ b/test/middleware.js
@@ -15,6 +15,23 @@ describe('MongoTenant', function() {
   describe('#Middleware', function() {
     utils.clearDatabase();
 
+    it('should inherit properties from Model when using discriminator', function (done) {
+      let 
+        TestModel = utils.createTestModel({ kind: String });
+
+      let 
+        DiscriminatorTest = utils.createTestModel({ inherit: Boolean });
+
+      DiscriminatorTest = TestModel.discriminator('DiscriminatorTest', DiscriminatorTest.schema);
+      
+      DiscriminatorTest.byTenant(1).create({ inherit: true, kind: 'test' }, (err, doc) => {
+        assert.equal(doc.__t, 'DiscriminatorTest');
+        assert(doc.inherit);
+        assert.equal(doc.kind, 'test');
+        done();
+      });
+    });
+
     it('should bind tenant context to Model.count().', function(done) {
       let
         TestModel = utils.createTestModel({});

--- a/test/middleware.js
+++ b/test/middleware.js
@@ -9,11 +9,28 @@
 
 const
   assert = require('chai').assert,
-  utils = require('./_utils');
+  utils = require('./_utils'),
+  Schema = require('mongoose').Schema;
 
 describe('MongoTenant', function() {
   describe('#Middleware', function() {
     utils.clearDatabase();
+
+    it('should add tenant on all discriminators of a model', function (done) {
+      let 
+        TestModel = utils.createTestModel({ kind: String }, {
+          schemaOptions : { discriminatorKey: 'kind' }
+        });
+
+      TestModel.discriminator('disc_key', new Schema({ inherit: Boolean }));
+
+      TestModel.byTenant(1).create({ inherit: true, kind: 'disc_key' }, (err, doc) => {
+        assert.equal(doc.tenantId, 1);
+        assert.equal(doc.inherit, true, 'does not inherit');
+        assert.equal(doc.kind, 'disc_key');
+        done();
+      });
+    });
 
     it('should inherit properties from Model when using discriminator', function (done) {
       let 
@@ -26,6 +43,7 @@ describe('MongoTenant', function() {
       
       DiscriminatorTest.byTenant(1).create({ inherit: true, kind: 'test' }, (err, doc) => {
         assert.equal(doc.__t, 'DiscriminatorTest');
+        assert.equal(doc.tenantId, 1);
         assert(doc.inherit);
         assert.equal(doc.kind, 'test');
         done();


### PR DESCRIPTION
When creating a discriminator and using together with node-mongo-tenant, we should also apply tenant to all model discriminators, otherwise tenant does not works.