### PR TITLE
 Secure deleteOne and deleteMany against tenant context jumping

### DIFF
--- a/index.js
+++ b/index.js
@@ -259,6 +259,18 @@ class MongoTenant {
         return super.aggregate.apply(this, operations);
       }
 
+      static deleteOne(conditions, callback) {
+        conditions[tenantIdKey] = this[tenantIdGetter]();
+
+        return super.deleteOne(conditions, callback);
+      }
+
+      static deleteMany(conditions, options, callback) {
+        conditions[tenantIdKey] = this[tenantIdGetter]();
+
+        return super.deleteMany(conditions, options, callback);
+      }
+
       static remove(conditions, callback) {
         if (arguments.length === 1 && typeof conditions === 'function') {
           callback = conditions;

--- a/test/integration.js
+++ b/test/integration.js
@@ -134,6 +134,26 @@ describe('MongoTenant', function() {
       });
     });
 
+    it('should bind Model.deleteOne(conditions, cb) to correct tenant context.', function(done) {
+      let TestModel = utils.createTestModel({});
+
+      TestModel.create({tenantId: 'tenant1'}, {tenantId: 'tenant2'}, (err) => {
+        assert(!err, 'Expected creation of 2 test entities to work.');
+
+        TestModel.byTenant('tenant1').deleteOne({tenantId: 'tenant2'}, (deletionError) => {
+          assert(!deletionError, 'Expected Model.deleteMany() to work');
+
+          TestModel.find({}, (lookupErr, entities) => {
+            assert(!lookupErr, 'Expected Model.find() to work.');
+            assert.equal(entities.length, 1, 'Expected to find only one entity.');
+            assert.equal(entities[0].tenantId, 'tenant2', 'Expected tenant2 scope on entity.');
+
+            done();
+          });
+        });
+      });
+    });
+
     it('should bind Model.deleteMany(conditions, options, cb) to correct tenant context.', function(done) {
       let TestModel = utils.createTestModel({num: Number});
 

--- a/test/integration.js
+++ b/test/integration.js
@@ -133,5 +133,25 @@ describe('MongoTenant', function() {
         );
       });
     });
+
+    it('should bind Model.deleteMany(conditions, options, cb) to correct tenant context.', function(done) {
+      let TestModel = utils.createTestModel({num: Number});
+
+      TestModel.create({tenantId: 'tenant1', num: 1}, {tenantId: 'tenant1', num: 1}, {tenantId: 'tenant2', num: 1}, (err) => {
+        assert(!err, 'Expected creation of 3 test entities to work.');
+
+        TestModel.byTenant('tenant1').deleteMany({num: 1}, (deletionError) => {
+          assert(!deletionError, 'Expected Model.deleteMany() to work');
+
+          TestModel.find({}, (lookupErr, entities) => {
+            assert(!lookupErr, 'Expected Model.find() to work.');
+            assert.equal(entities.length, 1, 'Expected to find only one entity.');
+            assert.equal(entities[0].tenantId, 'tenant2', 'Expected tenant2 scope on entity.');
+
+            done();
+          });
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
resolves #41 