### PR TITLE
Removes the preserveUniqueKey flag from index specification after using it

### DIFF
--- a/index.js
+++ b/index.js
@@ -170,6 +170,8 @@ class MongoTenant {
 
           index[0] = tenantAwareIndex;
         }
+        // Removes the possible preserveUniqueKey flag, that generates an validation error on MongoDB
+        delete index[1].preserveUniqueKey
       });
 
       // apply tenancy awareness to field level unique indexes


### PR DESCRIPTION
The flag presence on the index specification was causing mongoDB to throw the following error:

**The field 'preserveUniqueKey' is not valid for an index specification. Specification: { key: { associatedInsurance: 1.0 }, ..., preserveUniqueKey: true }**